### PR TITLE
First version of the helper

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,6 @@
-module.exports = {
+let rules = require('eslint-plugin-node').configs.recommended.rules; // eslint-disable-line no-undef
+
+module.exports = {// eslint-disable-line no-undef
   root: true,
   parserOptions: {
     ecmaVersion: 2017,
@@ -43,7 +45,7 @@ module.exports = {
         node: true
       },
       plugins: ['node'],
-      rules: Object.assign({}, require('eslint-plugin-node').configs.recommended.rules, {
+      rules: Object.assign({}, rules, {
         // add your custom rules and overrides for node files here
       })
     }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ember-import
 ==============================================================================
 
-[Short description of the addon.]
+`(import)` helper allows to import arbitrary modules into the template of an
+Ember application. 
 
 Installation
 ------------------------------------------------------------------------------
@@ -10,19 +11,30 @@ Installation
 ember install ember-import
 ```
 
-
 Usage
 ------------------------------------------------------------------------------
 
-[Longer description of how to use the addon in apps.]
+You can import any module using `{{import 'full-module-path/goes/here'}}`. This
+will automatically import the default export. 
 
+If you would like to change the name of the export that you want to import then 
+you can specify the name of the module after `?`. 
+
+For example, `{{import 'full-module-path/goes/here?otherExport'}}` will import
+`otherExport` from `full-module-path/goes/here`.
+
+Limitations
+------------------------------------------------------------------------------
+
+- Does not support relative imports
+- Does not allow async import
 
 Contributing
 ------------------------------------------------------------------------------
 
 ### Installation
 
-* `git clone <repository-url>`
+* `git clone git@github.com:taras/ember-import.git`
 * `cd ember-import`
 * `npm install`
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/taras/ember-import.svg?branch=master)](https://travis-ci.com/taras/ember-import)
+
 ember-import
 ==============================================================================
 

--- a/addon/helpers/import.js
+++ b/addon/helpers/import.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export function importHelper([pathName], /*, hash*/) {
+  let [path, name = 'default'] = pathName.split('?');
+  return window.require(path)[name];
+}
+
+export default helper(importHelper);

--- a/app/helpers/import.js
+++ b/app/helpers/import.js
@@ -1,0 +1,1 @@
+export { default, importHelper } from 'ember-import/helpers/import';

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  name: require('./package').name
+  name: require('./package').name,
 };

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "ember-import",
-  "version": "0.0.0",
-  "description": "The default blueprint for ember-cli addons.",
+  "version": "1.0.0",
+  "description": "Import arbitrary modules into scope templates",
   "keywords": [
     "ember-addon"
   ],
-  "repository": "",
+  "repository": "git@github.com:taras/ember-import.git",
   "license": "MIT",
-  "author": "",
+  "author": "Taras Mankovski <taras@frontside.io>",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/fixtures/hello-world.js
+++ b/tests/fixtures/hello-world.js
@@ -1,0 +1,3 @@
+export default 'hello world';
+
+export const withStars = '⭐️ hello world ⭐️'

--- a/tests/integration/import-test.js
+++ b/tests/integration/import-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | import', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it retrieves default export a name is not specified', async function(assert) {
+    await render(hbs`{{import 'dummy/tests/fixtures/hello-world'}}`);
+
+    assert.equal(this.element.textContent.trim(), 'hello world');
+  });
+
+  test('it retrieves specified export when name is specified', async function(assert) {
+    await render(hbs`{{import 'dummy/tests/fixtures/hello-world?withStars'}}`);
+
+    assert.equal(this.element.textContent.trim(), '⭐️ hello world ⭐️');
+  })
+});


### PR DESCRIPTION
`import` helper allow to import arbitrary modules into the template. This will be particularly useful with Microstates to import types without having to register them the dependency injection system.

To use the helper, you can use `{{import '<path>'}}` syntax.